### PR TITLE
cfengine3.service, will start other three services

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ these commands as the root user.
 2. stop the running CFEngine services, e.g. via ```/etc/init.d/cfengine3 stop```
 3. copy the unit files from the repository into `/etc/systemd/system`:<br/>```cp *.service /etc/systemd/system```<br/>(but see the note below)
 4. reload the configuration of systemd via ```systemctl daemon-reload```
-5. enable individual services that should be started by cfengine service:<br/>```systemctl enable cf-execd.service```<br/> and same for cf-execd.service and cf-monitord.service
+5. enable individual services that should be started by cfengine service:<br/>```systemctl enable cf-execd.service```<br/> and same for cf-serverd.service and cf-monitord.service
 6. start the new cfengine3.service:<br/> ```systemctl start cfengine3.service```
 7. to start services during boot enable cfengine3 service via
    ```systemctl enable cfengine3.service```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ This distribution provides service files for the three CFEngine daemons (in the 
 edition): cf-serverd, cf-execd and cf-monitord. `Restart=always` is
 set for the three daemons, so that if any of them
 dies for any reason, systemd will start a new instance nearly immediately.
-
+A service file for an "umbrella" cfengine3 service is also
+provided. Its function is to mask cfengine3.service file provided with
+the community edition that makes calls to the /etc/init.d/cfengine3
+file. Thee services cf-serverd, cf-exec-d and cf-monitord, when
+enabled, are installed as pre-requisites for cfengine3 service, making
+systemd to start them when cfengine3 is started.
 
 
 ## Installation
@@ -24,15 +29,15 @@ for Debian](https://cfengine.com/product/community/) and that you'll run
 these commands as the root user.
 
 1. copy/clone the contents of this repository
-2. fully disable the cfengine3 service, built automatically by systemd from
-the init.d file:<br/>```systemctl mask cfengine3.service```
+2. stop the running CFEngine services, e.g. via ```/etc/init.d/cfengine3 stop```
 3. copy the unit files from the repository into `/etc/systemd/system`:<br/>```cp *.service /etc/systemd/system```<br/>(but see the note below)
 4. reload the configuration of systemd via ```systemctl daemon-reload```
-5. stop the running CFEngine services, e.g. via ```/etc/init.d/cfengine3 stop```
-6. start the new separate services:<br/> ```systemctl start cf-serverd.service```<br/>and same for cf-execd.service and cf-monitord.service
+5. enable individual services that should be started by cfengine service:<br/>```systemctl enable cf-execd.service```<br/> and same for cf-execd.service and cf-monitord.service
+6. start the new cfengine3.service:<br/> ```systemctl start cfengine3.service```
+7. to start services during boot enable cfengine3 service via
+   ```systemctl enable cfengine3.service```
 
 If everything went well, you should like the output of the command `systemctl status cf-serverd cf-execd cf-monitord`. And if you kill one of the daemons and run the same command again you will like the output even more `:-)`
-
 
 **Note:** In Debian you also have the option to use
 `/usr/local/lib/systemd/system`, as reported in Debian's
@@ -44,3 +49,18 @@ You should use `/etc/systemd/system` for cross-distribution compatibility,
 but if you are on Debian and you're just experimenting,
 `/usr/local/lib/systemd/system` is also a viable choice.
 
+## "Umbrella" service and dependencies
+
+cfengine3.service does not start anything by itself. It is referenced
+by other three services in their "RequiredBy=" directives, which will
+make systemd create symbolic links to these individual services in the
+cfengine3.requires directory (most likely under /etc/systemd/system,
+but this might depend on a distribution) if those services are enabled
+with ```systemctl enable``` command. This in turn will instruct
+systemd to start those services when cfengine3 is started.
+
+Please note that even if individual services are enabled from the
+systemd's point of view (```systemctl is-enabled cf-execd``` returns
+```enabled```) it will not be started on boot if cfengine3.service is
+disabled. On the other hand all components of CFEngine can be enabled
+(or disabled) by only enabling (or disabling) cfengine3.service.

--- a/cf-execd.service
+++ b/cf-execd.service
@@ -10,12 +10,16 @@ After=network.target
 # for the service either...
 ConditionPathExists=/var/cfengine/inputs/promises.cf
 
+# The following allows activation of this service as part of cfengine3.service
+PartOf=cfengine3.service
 
 [Install]
 # The following ensures that this service is made part of the multi-user
 # target
 WantedBy=multi-user.target
 
+# the following ensure that cfengine3 start this service
+WantedBy=cfengine3.service
 
 [Service]
 Type=simple

--- a/cf-execd.service
+++ b/cf-execd.service
@@ -10,16 +10,15 @@ After=network.target
 # for the service either...
 ConditionPathExists=/var/cfengine/inputs/promises.cf
 
-# The following allows activation of this service as part of cfengine3.service
+# The following allows stopping/restarting of this service when
+# cfengine3.serice is stopped/restarted
 PartOf=cfengine3.service
 
 [Install]
-# The following ensures that this service is made part of the multi-user
-# target
-WantedBy=multi-user.target
-
-# the following ensure that cfengine3 start this service
-WantedBy=cfengine3.service
+# The following ensures that the symlink to this unit is created in the
+# cfengine3.service.requires/ directory when this unit is enabled
+# with "systemctl enable" command, and removed with "systemctl disable"
+RequiredBy=cfengine3.service
 
 [Service]
 Type=simple

--- a/cf-monitord.service
+++ b/cf-monitord.service
@@ -10,12 +10,16 @@ After=network.target
 # for the service either...
 ConditionPathExists=/var/cfengine/inputs/promises.cf
 
+# The following allows activation of this service as part of cfengine3.service
+PartOf=cfengine3.service
 
 [Install]
 # The following ensures that this service is made part of the multi-user
 # target
 WantedBy=multi-user.target
 
+# the following ensure that cfengine3 start this service
+WantedBy=cfengine3.service
 
 [Service]
 Type=simple

--- a/cf-monitord.service
+++ b/cf-monitord.service
@@ -10,16 +10,15 @@ After=network.target
 # for the service either...
 ConditionPathExists=/var/cfengine/inputs/promises.cf
 
-# The following allows activation of this service as part of cfengine3.service
+# The following allows stopping/restarting of this service when
+# cfengine3.serice is stopped/restarted
 PartOf=cfengine3.service
 
 [Install]
-# The following ensures that this service is made part of the multi-user
-# target
-WantedBy=multi-user.target
-
-# the following ensure that cfengine3 start this service
-WantedBy=cfengine3.service
+# The following ensures that the symlink to this unit is created in the
+# cfengine3.service.requires/ directory when this unit is enabled
+# with "systemctl enable" command, and removed with "systemctl disable"
+RequiredBy=cfengine3.service
 
 [Service]
 Type=simple

--- a/cf-serverd.service
+++ b/cf-serverd.service
@@ -11,12 +11,16 @@ After=network.target
 # for the service either...
 ConditionPathExists=/var/cfengine/inputs/promises.cf
 
+# The following allows activation of this service as part of cfengine3.service
+PartOf=cfengine3.service
 
 [Install]
 # The following ensures that this service is made part of the multi-user
 # target
 WantedBy=multi-user.target
 
+# the following ensure that cfengine3 start this service
+WantedBy=cfengine3.service
 
 [Service]
 Type=simple

--- a/cf-serverd.service
+++ b/cf-serverd.service
@@ -11,16 +11,15 @@ After=network.target
 # for the service either...
 ConditionPathExists=/var/cfengine/inputs/promises.cf
 
-# The following allows activation of this service as part of cfengine3.service
+# The following allows stopping/restarting of this service when
+# cfengine3.serice is stopped/restarted
 PartOf=cfengine3.service
 
 [Install]
-# The following ensures that this service is made part of the multi-user
-# target
-WantedBy=multi-user.target
-
-# the following ensure that cfengine3 start this service
-WantedBy=cfengine3.service
+# The following ensures that the symlink to this unit is created in the
+# cfengine3.service.requires/ directory when this unit is enabled
+# with "systemctl enable" command, and removed with "systemctl disable"
+RequiredBy=cfengine3.service
 
 [Service]
 Type=simple

--- a/cfengine3.service
+++ b/cfengine3.service
@@ -4,8 +4,6 @@ Documentation=https://docs.cfengine.com/lts
 
 After=network.target
 
-Requires=cf-execd.service cf-monitord.service cf-serverd.service
-
 [Service]
 Type=oneshot
 ExecStart=/bin/true

--- a/cfengine3.service
+++ b/cfengine3.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=CFEngine 3 daemons
+Documentation=https://docs.cfengine.com/lts
+
+After=network.target
+
+Requires=cf-execd.service cf-monitord.service cf-serverd.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/true
+ExecReload=/bin/true
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
During a bootstrap process on systems where systemd is installed CFEngine will attempt to "systemctl restart cfengine3".

This patch introduces cfengine3.service that will restart cf-execd, cf-monitord and cf-serverd.

If cfengine3.service is saved in /etc/systemd/system/ directory it will override the one provided by the CFEngine.
